### PR TITLE
fix: make time format more strict to stop invalid time date flowing

### DIFF
--- a/src/dve/metadata_parser/domain_types.py
+++ b/src/dve/metadata_parser/domain_types.py
@@ -519,9 +519,8 @@ class FormattedTime(dt.time):
             raise ValueError("Provided time has timezone, but this is forbidden for this field")
         if cls.TIMEZONE_TREATMENT == "require" and not new_time.tzinfo:
             raise ValueError("Provided time missing timezone, but this is required for this field")
-        if isinstance(value, str) and cls.TIME_FORMAT:
-            if value != str(new_time):
-                raise ValueError("Provided time is not matching expected time format supplied.")
+        if isinstance(value, str) and cls.TIME_FORMAT and value != str(new_time):
+            raise ValueError("Provided time is not matching expected time format supplied.")
         return new_time
 
     @classmethod

--- a/src/dve/metadata_parser/domain_types.py
+++ b/src/dve/metadata_parser/domain_types.py
@@ -519,7 +519,9 @@ class FormattedTime(dt.time):
             raise ValueError("Provided time has timezone, but this is forbidden for this field")
         if cls.TIMEZONE_TREATMENT == "require" and not new_time.tzinfo:
             raise ValueError("Provided time missing timezone, but this is required for this field")
-
+        if isinstance(value, str) and cls.TIME_FORMAT:
+            if value != str(new_time):
+                raise ValueError("Provided time is not matching expected time format supplied.")
         return new_time
 
     @classmethod

--- a/tests/test_model_generation/test_domain_types.py
+++ b/tests/test_model_generation/test_domain_types.py
@@ -335,9 +335,6 @@ def test_reportingperiod_raises(field, value):
         ["23:00:00Z", None, "require", dt.time(23, 0, 0, tzinfo=UTC)],
         ["12:00:00Zam", None, "permit", dt.time(0, 0, 0, tzinfo=UTC)],
         ["12:00:00pm", None, "forbid", dt.time(12, 0, 0)],
-        ["1970-01-01", "%Y-%m-%d", "forbid", dt.time(0, 0)],
-        # not great that it effectively returns incorrect time object here. However, this would be
-        # down to user error in setting up the dischema.
         [dt.datetime(2025, 12, 1, 13, 0, 5), "%H:%M:%S", "forbid", dt.time(13, 0, 5)],
         [dt.datetime(2025, 12, 1, 13, 0, 5, tzinfo=UTC), "%H:%M:%S", "require", dt.time(13, 0, 5, tzinfo=UTC)],
         [dt.time(13, 0, 0), "%H:%M:%S", "forbid", dt.time(13, 0, 0)],
@@ -364,6 +361,9 @@ def test_formattedtime(
         ["23:00:00", "%I:%M:%S", "permit",],
         ["23:00:00", "%H:%M:%S", "require",],
         ["23:00:00Z", "%I:%M:%S", "forbid",],
+        ["2:10:13", "%H:%M:%S", "forbid",],
+        ["20:0:13", "%H:%M:%S", "forbid",],
+        ["20:10:1", "%H:%M:%S", "forbid",],
         [dt.datetime(2025, 12, 1, 13, 0, 5, tzinfo=UTC), "%H:%M:%S", "forbid",],
         [dt.time(13, 0, 5, tzinfo=UTC), "%H:%M:%S", "forbid",],
         ["12:00", "%H:%M:%S", "forbid",],


### PR DESCRIPTION
## TLDR of changes
Time format domain type in specific circumstances is not strict enough allowing indeterminate values to flow through. E.g. 12:3:12. Is this 12:30 or 12:03? Now it raises an error.

## What kind of changes does this PR introduce?

__Tick all that apply__

- [x] fix: A bug fix. Correlates with PATCH in SemVer
- [ ] feat: A new feature. Correlates with MINOR in SemVer
- [ ] docs: Documentation only changes
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] perf: A code change that improves performance
- [ ] test: Adding missing or correcting existing tests
- [ ] build: Changes that affect the build system or external dependencies (example scopes: pip, docker, npm)
- [ ] ci: Changes to CI configuration files and scripts (example scopes: GitLabCI)


## Please check if the PR fulfills these requirements

- [x] I have read and followed the [Contributing guidance](../CONTRIBUTE.md)
- [x] Docs have been added / updated
- [x] Tests and Linting in the CI are passing
- [x] Changes have been reviewed and approved by a Project Maintainer
